### PR TITLE
Simplify onboarding experience

### DIFF
--- a/.spin-inventory.example.ini
+++ b/.spin-inventory.example.ini
@@ -1,6 +1,6 @@
-####################
-# Host Types
-####################
+###########################################
+# 👇 Basic Server Configuration - Set your server DNS or IP address
+###########################################
 
 [production_manager_servers]
 # server01.example.com
@@ -8,16 +8,15 @@
 [staging_manager_servers]
 # server02.example.com
 
-####################
-# Swarm Roles
-####################
+###########################################
+# 🤓 Advanced Envioronment Settings
+###########################################
+# Swarm Configuration
 [swarm_managers:children]
 production_manager_servers
 staging_manager_servers
 
-####################
 # Environment
-####################
 [production:children]
 production_manager_servers
 

--- a/.spin.example.yml
+++ b/.spin.example.yml
@@ -1,9 +1,52 @@
 ---
 ###########################################
-# Basic Server Configuration
+# 👇 Basic Server Configuration - Change your email
 ###########################################
 server_timezone: "Etc/UTC"
 server_contact: changeme@example.com
+
+##############################################################
+# 👇 Users - You must set at least one user
+##############################################################
+
+### Use the template below to set users and their authorized keys
+## Passwords are optional if you use passwordless sudo. If you do
+## use passwords, you must be set with an encrypted hash. You can 
+## generate an encrypted hash with `spin mkpasswd`. Learn more:
+## https://serversideup.net/open-source/spin/docs/command-reference/mkpasswd
+
+# users:
+#   - username: alice
+#     name: Alice Smith
+#     groups: ['adm','sudo']
+#     authorized_keys:
+#       - public_key: "ssh-ed25519 AAAAC3NzaC1lmyfakeublickeyMVIzwQXBzxxD9b8Erd1FKVvu alice"
+
+#   - username: bob
+#     name: Bob Smith
+#     state: present
+#     password: "$6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1"
+#     groups: ['adm','sudo']
+#     shell: "/bin/bash"
+#     authorized_keys:
+#       - public_key: "ssh-ed25519 AAAAC3NzaC1anotherfakekeyIMVIzwQXBzxxD9b8Erd1FKVvu bob"
+
+##############################################################
+# 👇 Deploy User - If you're using GitHub Actions, create a dedicated deploy key
+##############################################################
+
+### Learn how to create a secure DEPLOY key and enter the public value below
+## https://serversideup.net/open-source/spin/docs/advanced/generating-a-secure-ssh-key#generating-a-deployment-key
+
+# docker_user:
+#   username: deploy
+#   authorized_ssh_keys: 
+#     - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNJGtd7a4DBHsQi7HGrC5xz0eAEFHZ3Ogh3FEFI2345 fake@key"
+#     - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFRfXxUZ8q9vHRcQZ6tLb0KwGHu8xjQHfYopZKLmnopQ anotherfake@key"
+
+###########################################
+# Advanced Server Configuration
+###########################################
 
 # If you the SSH port below, you may need to run `spin provision -p <your-default-ssh-port>`
 # to get a connection on your first provision. Otherwise, SSH will try connecting 
@@ -19,50 +62,5 @@ postfix_hostname: "{{ inventory_hostname }}"
 # postfix_relayhost_username: "myusername"
 # postfix_relayhost_password: "mysupersecretpassword"
 
-## Configure passwordless sudo for the sudo group (it's disabled by default)
-# use_passwordless_sudo: true
-
-##############################################################
-# Deploy User
-##############################################################
-# Docker user configuration.
-docker_user:
-  username: deploy
-  gid: 9999
-  group: deploy
-  home: "/home/deploy"
-  secondary_groups: "docker"
-  uid: 9999
-  ## Uncomment to set authorized SSH keys for the docker user.
-  # authorized_ssh_keys: 
-  #   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNJGtd7a4DBHsQi7HGrC5xz0eAEFHZ3Ogh3FEFI2345 fake@key"
-  #   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFRfXxUZ8q9vHRcQZ6tLb0KwGHu8xjQHfYopZKLmnopQ anotherfake@key"
-
-##############################################################
-# Users
-##############################################################
-
-### Use the template below to set users and their authorized keys
-## Passwords are optional if you use passwordless sudo. If you do
-## use passwords, you must be set with an encrypted hash. You can 
-## generate an encrypted hash with `spin mkpasswd`. Learn more:
-## https://serversideup.net/open-source/spin/docs/command-reference/mkpasswd
-
-# users:
-#   - username: alice
-#     name: Alice Smith
-#     state: present
-#     groups: ['adm','sudo']
-#     password: "$6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1"
-#     shell: "/bin/bash"
-#     authorized_keys:
-#       - public_key: "ssh-ed25519 AAAAC3NzaC1lmyfakeublickeyMVIzwQXBzxxD9b8Erd1FKVvu alice"
-
-#   - username: bob
-#     name: Bob Smith
-#     state: present
-#     password: "$6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1"
-#     groups: ['adm','sudo']
-#     shell: "/bin/bash"
-#     authorized_keys:
-#       - public_key: "ssh-ed25519 AAAAC3NzaC1anotherfakekeyIMVIzwQXBzxxD9b8Erd1FKVvu bob"
+## You can set this to false to require a password for sudo.
+use_passwordless_sudo: true

--- a/.spin.example.yml
+++ b/.spin.example.yml
@@ -53,6 +53,9 @@ server_contact: changeme@example.com
 # to your new port before the SSH server configuration is updated.
 ssh_port: "22"
 
+## You can set this to false to require a password for sudo.
+use_passwordless_sudo: true
+
 ## Email Notifications
 postfix_hostname: "{{ inventory_hostname }}"
 
@@ -61,6 +64,3 @@ postfix_hostname: "{{ inventory_hostname }}"
 # postfix_relayhost_port: "587"
 # postfix_relayhost_username: "myusername"
 # postfix_relayhost_password: "mysupersecretpassword"
-
-## You can set this to false to require a password for sudo.
-use_passwordless_sudo: true

--- a/.spin.example.yml
+++ b/.spin.example.yml
@@ -45,7 +45,7 @@ server_contact: changeme@example.com
 #     - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFRfXxUZ8q9vHRcQZ6tLb0KwGHu8xjQHfYopZKLmnopQ anotherfake@key"
 
 ###########################################
-# Advanced Server Configuration
+# 🤓 Advanced Server Configuration
 ###########################################
 
 # If you the SSH port below, you may need to run `spin provision -p <your-default-ssh-port>`

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: serversideup
 name: spin
-version: 1.1.0
+version: 1.2.0
 readme: README.md
 authors:
   - Jay Rogers (https://x.com/jaydrogers)

--- a/molecule/default/vars.yml
+++ b/molecule/default/vars.yml
@@ -1,5 +1,7 @@
 server_timezone: "America/Chicago"
 
+use_passwordless_sudo: true
+
 users:
   - username: alice
     name: Alice Smith
@@ -21,11 +23,7 @@ users:
 
 additional_users:
   - username: charlie
-    name: Charlie Smith
-    state: present
     groups: ['adm', 'sudo']
-    password: "$6$IXlCqhTY2T$nDnDJRcvk59V2yb3O4Z9n0zO70z/xVCllphjrJ.L618OvHfSs1hciwtxUS/UxR7tF5xWcwzRr3eHboiSHFG7I1"
-    shell: "/bin/bash"
     authorized_keys:
       - public_key: "ssh-ed25519 AAAAC3NzaC1lmyfakeublickeyMVIzwQXBzxxD9b8Erd1FKVvu charlie"
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -42,9 +42,9 @@
     - name: Assert docker user exists.
       assert:
         that:
-          - docker_user_test.name == "{{ docker_user.username }}"
+          - docker_user_test.name == docker_user.username
           - docker_user_test.changed == false
-          - docker_user_test.uid == {{ docker_user.uid }}
+          - docker_user_test.uid == docker_user.uid
         fail_msg: "Failed to assert the Docker user exists."
     
     - name: Get Docker & Docker Swarm info.

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -6,6 +6,7 @@
   vars:
     ansible_port: "{{ ssh_port }}"
     ansible_ssh_common_args: "-o IgnoreUnknown=UseKeychain"
+    ansible_python_interpreter: auto_silent
   roles:
     - serversideup.spin.linux_common
     - serversideup.spin.swarm

--- a/roles/linux_common/tasks/users.yml
+++ b/roles/linux_common/tasks/users.yml
@@ -16,7 +16,7 @@
     groups: '{{ item.groups | join(",") | default(omit) }}'
     home: '{{ item.homedir | default(omit) }}'
     password: '{{ item.password | default(omit) }}'
-    shell: '{{ item.shell | default(omit) }}'
+    shell: '{{ item.shell | default("/bin/bash") }}'
     state: '{{ item.state | default("present") }}'
     uid: '{{ item.uid | default(omit) }}'
     update_password: '{{ item.update_password | default("on_create") }}'

--- a/roles/swarm/defaults/main.yml
+++ b/roles/swarm/defaults/main.yml
@@ -38,3 +38,32 @@ docker_user:
 docker_swarm:
   # Use "default_ipv4.address" and fail to first available IP if not set.
   advertise_addr: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"
+
+##############################################################
+# Users
+##############################################################
+
+### Use the template below to set users and their authorized keys
+## Passwords are optional if you use passwordless sudo. If you do
+## use passwords, you must be set with an encrypted hash. You can 
+## generate an encrypted hash with `spin mkpasswd`. Learn more:
+## https://serversideup.net/open-source/spin/docs/command-reference/mkpasswd
+
+# users:
+#   - username: alice
+#     name: Alice Smith
+#     state: present
+#     groups: ['adm','sudo']
+#     password: "$6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1"
+#     shell: "/bin/bash"
+#     authorized_keys:
+#       - public_key: "ssh-ed25519 AAAAC3NzaC1lmyfakeublickeyMVIzwQXBzxxD9b8Erd1FKVvu alice"
+
+#   - username: bob
+#     name: Bob Smith
+#     state: present
+#     password: "$6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1"
+#     groups: ['adm','sudo']
+#     shell: "/bin/bash"
+#     authorized_keys:
+#       - public_key: "ssh-ed25519 AAAAC3NzaC1anotherfakekeyIMVIzwQXBzxxD9b8Erd1FKVvu bob"


### PR DESCRIPTION
# What this PR does
- Set our default template to `use_passwordless_sudo: true` to simplify onboarding experience
- Organized and set other defaults for our default inventory and `.spin.yml` files for easier onboarding
- Cleaned up some basic testing