### PR TITLE
Fix #11 - Python PIP issue with Digital Ocean

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: serversideup
 name: spin
-version: 2.1.0
+version: 2.1.1
 readme: README.md
 authors:
   - Jay Rogers (https://x.com/jaydrogers)

--- a/roles/linux_common/README.md
+++ b/roles/linux_common/README.md
@@ -50,6 +50,7 @@ common_installed_packages:
   - ncdu
   - ntp
   - python3-minimal
+  - python3-pip
   - ssh
   - tzdata
   - ufw

--- a/roles/linux_common/defaults/main.yml
+++ b/roles/linux_common/defaults/main.yml
@@ -39,6 +39,7 @@ common_installed_packages:
   - ncdu
   - ntp
   - python3-minimal
+  - python3-pip
   - ssh
   - tzdata
   - ufw


### PR DESCRIPTION
# What this PR does
- Fixes issue in #11 where `python3-pip` was missing as a dependency